### PR TITLE
Only update the buffer when the rufo call is successful

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -3,14 +3,14 @@
 # * :dynamic: if there's a space, keep it. If not, don't add it
 # * :always: always put a space after an array bracket (default)
 # * :never: never put a space after an array bracket
-space_after_array_bracket :never
+spaces_inside_array_bracket :never
 
 # Whether to put a space after a hash brace. Valid values are:
 #
 # * :dynamic: if there's a space, keep it. If not, don't add it (default)
 # * :always: always put a space after a hash brace
 # * :never: never put a space after a hash brace
-space_after_hash_brace :always
+spaces_inside_hash_brace :always
 
 # Whether to align successive comments (default: false)
 align_comments false
@@ -27,22 +27,6 @@ align_case_when true
 # Whether to align chained calls to the first dot in the first line (default: false)
 align_chained_calls false
 
-# Preserve whitespace after assignments target and values,
-# after calls that start with a space, hash arrows and commas (default: true).
-#
-# This allows for manual alignment of some code that would otherwise
-# be impossible to automatically format or preserve "beautiful".
-#
-# If `align_assignments` is true, this doesn't apply to assignments.
-# If `align_hash_keys` is true, this doesn't apply to hash keys.
-#
-#
-# Can also be set to `:YES` to preserve whitespace in many more places,
-# in case there's no clear rule in your workplace/project as to when
-# to leave spaces or not. This includes spaces (or the absence of them)
-# around dots, braces, pipes and hash keys and values.
-preserve_whitespace true
-
 # The indent size (default: 2)
 indent_size 2
 
@@ -52,3 +36,5 @@ indent_size 2
 # * :always: always put a comma
 # * :never: never put a comma
 trailing_commas :always
+
+parens_in_def :yes

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "rufo", ">= 0.0.32"
+gem "rufo", ">= 0.0.38"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rufo (0.0.32)
+    rufo (0.0.38)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rufo (>= 0.0.32)
+  rufo (>= 0.0.38)
 
 BUNDLED WITH
    1.15.1

--- a/rufo.el
+++ b/rufo.el
@@ -165,6 +165,10 @@
         (erase-buffer))
       (kill-buffer errbuf))))
 
+(defun rufo-minor-mode--should-apply-patch-p (rufo-status-code)
+  "Check if the file needs changes based on `RUFO-STATUS-CODE'."
+  (eq rufo-status-code 3))
+
 (defun rufo-format ()
   "Format the current buffer with rufo."
   (interactive)
@@ -190,7 +194,7 @@
           (setq rufo-call-result (if rufo-args
                                      (apply 'call-process-region (point-min) (point-max) executable nil (list :file outputfile) nil rufo-args)
                                    (call-process-region (point-min) (point-max) executable nil (list :file outputfile) nil)))
-          (when (eq 0 rufo-call-result)
+          (when (rufo-minor-mode--should-apply-patch-p rufo-call-result)
             (call-process-region nil nil "diff" nil patchbuf nil "-n" "--text" "-" outputfile)
             (rufo-minor-mode--apply-rcs-patch patchbuf)
             (message "Applied rufo with args `%s'" rufo-args)


### PR DESCRIPTION
If the `rufo` call results in an error, this plugin is currently updating the buffer without checking if the diff will be successful or not.

For instance, code like this:

```ruby
# notice the erroneous hash syntax
let(:my_hash) {  key: { a: 1, b: 2 }  }
```

Will be replaced by the following text:

```
Error: the given text is not a valid ruby program (it has syntax errors)
```

This code fixes that by checking the `rufo` result code before calling the buffer update code.