### PR TITLE
Fix rufo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Minor-mode to automatically format ruby with [rufo][].
 
-**Note:** `rufo.el` only supports `rufo >= 0.0.38` because of the [exit codes introduced in that version](https://github.com/asterite/rufo/pull/109)
+**Note:** `rufo.el` only supports `rufo >= 0.0.38`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can enable `rufo-minor-mode-debug-mode` which will output additional info in
 * The authors of [go-mode.el][], from which I copied the RCS diff application code
 * All [contributors](https://github.com/danielma/rufo.el/graphs/contributors)
 
-[rufo]: https://github.com/asterite/rufo
+[rufo]: https://github.com/ruby-formatter/rufo
 [eslintd-fix]: https://github.com/aaronjensen/eslintd-fix
 [@aaronjensen]: https://github.com/aaronjensen
 [go-mode.el]: https://github.com/dominikh/go-mode.el

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Minor-mode to automatically format ruby with [rufo][].
 
-**Note:** `rufo.el` only supports `rufo >= 0.0.38`.
+**Note:** `rufo.el` only supports `rufo >= 0.0.38` because of [the exit codes introduced in that version](https://github.com/ruby-formatter/rufo/commit/068bf0b417f4b8a82c5b14f7d5858f5cdf42a713).
 
 ## Usage
 

--- a/rufo.el
+++ b/rufo.el
@@ -40,7 +40,7 @@
 ;;; Commentary:
 
 ;; This package provides the rufo-minor-mode minor mode, which will use rufo
-;; (https://github.com/asterite/rufo) to automatically fix ruby code
+;; (https://github.com/ruby-formatter/rufo) to automatically fix ruby code
 ;; when it is saved.
 
 ;; To use it, require it, make sure `rufo' is in your path and add it to


### PR DESCRIPTION
It seems that rufo repo moved to https://github.com/ruby-formatter/rufo. 
This PR replaces the old url with a new one.